### PR TITLE
fix: update get avg to supports only numeric fields

### DIFF
--- a/src/lib/aggregations/get-avg.spec.ts
+++ b/src/lib/aggregations/get-avg.spec.ts
@@ -1,16 +1,78 @@
+import { ResponseError } from '@elastic/elasticsearch/lib/errors.js'
 import { HomeDocument } from 'test/module'
+import { TEST_ELASTICSEARCH_NODE } from 'test/constants'
+import { setupNestApplication } from 'test/toolkit'
+import { ElasticsearchModule } from 'module/elasticsearch.module'
+import { ElasticsearchService } from 'module/elasticsearch.service'
 import { getAvgAggregation } from './get-avg'
 
 describe('getAvgAggregation', () => {
+    const { app } = setupNestApplication({
+        imports: [
+            ElasticsearchModule.register({
+                node: TEST_ELASTICSEARCH_NODE
+            })
+        ]
+    })
+
     it('accepts only schema field', () => {
-        const query = getAvgAggregation<HomeDocument>('address')
+        const query = getAvgAggregation<HomeDocument>('builtInYear')
 
         expect(query).toEqual({
             avg: {
-                field: 'address'
+                field: 'builtInYear'
             }
         })
     })
 
-    test.todo('accepts only schema field with keyword')
+    it('should queries elasticsearch for avg aggregation ', async () => {
+        const service = app.get(ElasticsearchService)
+
+        const result = await service.search(HomeDocument, {
+            size: 0,
+            aggregations: {
+                testAggregation: getAvgAggregation('builtInYear')
+            }
+        })
+
+        expect(result.aggregations.testAggregation.value).toBeDefined()
+    })
+
+    it(`should return an error when after passing 'keyword'`, async () => {
+        const service = app.get(ElasticsearchService)
+
+        await service
+            .search(HomeDocument, {
+                size: 0,
+                aggregations: {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    testAggregation: getAvgAggregation('address.keyword') as any
+                }
+            })
+            .catch(error => {
+                expect(error).toBeInstanceOf(ResponseError)
+                expect(error.message).toContain('search_phase_execution_exception: [illegal_argument_exception]')
+                expect(error.message).toContain('Field [address.keyword] of type [keyword] is not supported for aggregation [avg]')
+            })
+    })
+
+    it(`should return an error when after passing 'keyword'`, async () => {
+        const service = app.get(ElasticsearchService)
+
+        await service
+            .search(HomeDocument, {
+                size: 0,
+                aggregations: {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    testAggregation: getAvgAggregation('address') as any
+                }
+            })
+            .catch(error => {
+                expect(error).toBeInstanceOf(ResponseError)
+                expect(error.message).toContain('search_phase_execution_exception: [illegal_argument_exception]')
+                expect(error.message).toContain(
+                    'Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default.'
+                )
+            })
+    })
 })

--- a/src/lib/aggregations/get-avg.spec.ts
+++ b/src/lib/aggregations/get-avg.spec.ts
@@ -38,25 +38,7 @@ describe('getAvgAggregation', () => {
         expect(result.aggregations.testAggregation.value).toBeDefined()
     })
 
-    it(`should return an error when after passing 'keyword'`, async () => {
-        const service = app.get(ElasticsearchService)
-
-        await service
-            .search(HomeDocument, {
-                size: 0,
-                aggregations: {
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    testAggregation: getAvgAggregation('address.keyword') as any
-                }
-            })
-            .catch(error => {
-                expect(error).toBeInstanceOf(ResponseError)
-                expect(error.message).toContain('search_phase_execution_exception: [illegal_argument_exception]')
-                expect(error.message).toContain('Field [address.keyword] of type [keyword] is not supported for aggregation [avg]')
-            })
-    })
-
-    it(`should return an error when after passing 'keyword'`, async () => {
+    it(`should return an error when after passing string field`, async () => {
         const service = app.get(ElasticsearchService)
 
         await service
@@ -73,6 +55,24 @@ describe('getAvgAggregation', () => {
                 expect(error.message).toContain(
                     'Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default.'
                 )
+            })
+    })
+
+    it(`should return an error when after passing string field with "keyword"`, async () => {
+        const service = app.get(ElasticsearchService)
+
+        await service
+            .search(HomeDocument, {
+                size: 0,
+                aggregations: {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    testAggregation: getAvgAggregation('address.keyword') as any
+                }
+            })
+            .catch(error => {
+                expect(error).toBeInstanceOf(ResponseError)
+                expect(error.message).toContain('search_phase_execution_exception: [illegal_argument_exception]')
+                expect(error.message).toContain('Field [address.keyword] of type [keyword] is not supported for aggregation [avg]')
             })
     })
 })

--- a/src/lib/aggregations/get-avg.spec.ts
+++ b/src/lib/aggregations/get-avg.spec.ts
@@ -15,7 +15,7 @@ describe('getAvgAggregation', () => {
         ]
     })
 
-    it('accepts only schema field', () => {
+    it('accepts only schema numeric field', () => {
         const query = getAvgAggregation<HomeDocument>('builtInYear')
 
         expect(query).toEqual({

--- a/src/lib/aggregations/get-avg.ts
+++ b/src/lib/aggregations/get-avg.ts
@@ -1,8 +1,4 @@
-import { Document } from 'lib/common'
-
-type NumericField<TDocument extends Document> = {
-    [K in keyof TDocument]: Exclude<TDocument[K], undefined> extends number ? K : never
-}[keyof TDocument]
+import { Document, NumericField } from 'lib/common'
 
 export type AvgAggregationBody<TDocument extends Document> = {
     field: NumericField<TDocument>

--- a/src/lib/aggregations/get-avg.ts
+++ b/src/lib/aggregations/get-avg.ts
@@ -1,15 +1,17 @@
-import { Document, Field } from 'lib/common'
+import { Document } from 'lib/common'
+
+type NumericField<TDocument extends Document> = {
+    [K in keyof TDocument]: Exclude<TDocument[K], undefined> extends number ? K : never
+}[keyof TDocument]
 
 export type AvgAggregationBody<TDocument extends Document> = {
-    field: Field<TDocument>
+    field: NumericField<TDocument>
 }
 
 export type AvgAggregation<TDocument extends Document> = {
     avg: AvgAggregationBody<TDocument>
 }
 
-export const getAvgAggregation = <TDocument extends Document, TField extends Field<TDocument> = Field<TDocument>>(
-    field: TField
-): AvgAggregation<TDocument> => ({
+export const getAvgAggregation = <TDocument extends Document>(field: NumericField<TDocument>): AvgAggregation<TDocument> => ({
     avg: { field }
 })

--- a/src/lib/common/field.ts
+++ b/src/lib/common/field.ts
@@ -8,3 +8,6 @@ export type FieldType<TDocument extends Document, TField extends Key<TDocument> 
     ? Fields<TDocument>[TField]
     : // eslint-disable-next-line @typescript-eslint/no-explicit-any
       any
+export type NumericField<TDocument extends Document> = {
+    [K in keyof TDocument]: Exclude<TDocument[K], undefined> extends number ? K : never
+}[keyof TDocument]


### PR DESCRIPTION
According to [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-aggregations-metrics-avg-aggregation.html#search-aggregations-metrics-avg-aggregation) avg aggregation supports only numeric fields.