### PR TITLE
Histogram

### DIFF
--- a/src/lib/aggregations/get-avg.spec.ts
+++ b/src/lib/aggregations/get-avg.spec.ts
@@ -58,7 +58,7 @@ describe('getAvgAggregation', () => {
             })
     })
 
-    it(`should return an error after passing string field with "keyword"`, async () => {
+    it(`should return an error after passing string field with 'keyword'`, async () => {
         const service = app.get(ElasticsearchService)
 
         await service

--- a/src/lib/aggregations/get-histogram.spec.ts
+++ b/src/lib/aggregations/get-histogram.spec.ts
@@ -1,17 +1,107 @@
+import { ResponseError } from '@elastic/elasticsearch/lib/errors.js'
 import { HomeDocument } from 'test/module'
+import { TEST_ELASTICSEARCH_NODE } from 'test/constants'
+import { setupNestApplication } from 'test/toolkit'
+import { ElasticsearchModule } from 'module/elasticsearch.module'
+import { ElasticsearchService } from 'module/elasticsearch.service'
 import { getHistogramAggregation } from './get-histogram'
 
 describe('getHistogramAggregation', () => {
-    it('accepts only schema field', () => {
-        const query = getHistogramAggregation<HomeDocument>('city', 5)
+    const { app } = setupNestApplication({
+        imports: [
+            ElasticsearchModule.register({
+                node: TEST_ELASTICSEARCH_NODE
+            })
+        ]
+    })
+
+    it('accepts only schema numeric field', () => {
+        const query = getHistogramAggregation<HomeDocument>('propertyAreaSquared', 5)
 
         expect(query).toEqual({
             histogram: {
-                field: 'city',
+                field: 'propertyAreaSquared',
                 interval: 5
             }
         })
     })
 
-    test.todo('accepts only schema field with keyword')
+    it('should queries elasticsearch for histogram aggregation', async () => {
+        const service = app.get(ElasticsearchService)
+
+        const result = await service.search(HomeDocument, {
+            size: 0,
+            aggregations: {
+                testAggregation: getHistogramAggregation('builtInYear', 5)
+            }
+        })
+
+        const responseBuckets = result.aggregations.testAggregation.buckets
+
+        responseBuckets.forEach(bucket => {
+            expect(bucket).toEqual(
+                expect.objectContaining({
+                    key: expect.any(Number),
+                    doc_count: expect.any(Number)
+                })
+            )
+        })
+    })
+
+    it('should queries elasticsearch for histogram aggregation with min_doc_count', async () => {
+        const service = app.get(ElasticsearchService)
+        const minDocCount = 10
+
+        const result = await service.search(HomeDocument, {
+            size: 0,
+            aggregations: {
+                testAggregation: getHistogramAggregation('builtInYear', 5, minDocCount)
+            }
+        })
+
+        const responseBuckets = result.aggregations.testAggregation.buckets
+
+        responseBuckets.forEach(bucket => {
+            console.log(bucket)
+            expect(bucket.doc_count).toBeGreaterThanOrEqual(minDocCount)
+        })
+    })
+
+    it(`should return an error after passing string field`, async () => {
+        const service = app.get(ElasticsearchService)
+
+        await service
+            .search(HomeDocument, {
+                size: 0,
+                aggregations: {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    histogram: getHistogramAggregation('propertyAreaSquaredAsString' as any, 5)
+                }
+            })
+            .catch(error => {
+                expect(error).toBeInstanceOf(ResponseError)
+                expect(error.message).toContain('search_phase_execution_exception: [illegal_argument_exception]')
+                expect(error.message).toContain(
+                    'Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default.'
+                )
+            })
+    })
+
+    it(`should return an error after passing string field with 'keyword'`, async () => {
+        const service = app.get(ElasticsearchService)
+
+        await service
+            .search(HomeDocument, {
+                size: 0,
+                aggregations: {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    testAggregation: getHistogramAggregation('address.keyword' as any, 5)
+                }
+            })
+            .catch(error => {
+                expect(error).toBeInstanceOf(ResponseError)
+                expect(error.message).toContain('search_phase_execution_exception: [illegal_argument_exception]')
+                expect(error.message).toContain('Field [address.keyword] of type [keyword] is not supported for aggregation [histogram]')
+            })
+    })
 })

--- a/src/lib/aggregations/get-histogram.ts
+++ b/src/lib/aggregations/get-histogram.ts
@@ -1,14 +1,23 @@
-import { Document, Key } from 'lib/common'
+import { Document, NumericField } from 'lib/common'
 
 export type HistogramAggregationBody<TDocument extends Document> = {
-    field: Key<TDocument>
+    field: NumericField<TDocument>
     interval: number
+    min_doc_count?: number
 }
 
 export type HistogramAggregation<TDocument extends Document> = {
     histogram: HistogramAggregationBody<TDocument>
 }
 
-export const getHistogramAggregation = <TDocument extends Document>(field: Key<TDocument>, interval: number): HistogramAggregation<TDocument> => ({
-    histogram: { field, interval }
+export const getHistogramAggregation = <TDocument extends Document>(
+    field: NumericField<TDocument>,
+    interval: number,
+    min_doc_count?: number
+): HistogramAggregation<TDocument> => ({
+    histogram: {
+        field,
+        interval,
+        min_doc_count
+    }
 })

--- a/src/lib/aggregations/types.ts
+++ b/src/lib/aggregations/types.ts
@@ -1,6 +1,7 @@
 import { Document } from 'lib/common'
 import { AvgAggregation } from './get-avg'
 import { DateHistogramAggregation } from './get-date-histogram'
+import { HistogramAggregation } from './get-histogram'
 import { MissingValueAggregation } from './get-missing-value'
 import { PercentileAggregation } from './get-percentile'
 import { RangeAggregation } from './get-range'
@@ -20,6 +21,7 @@ export type AggregationList<TDocument extends Document> =
     | SumAggregation<TDocument>
     | MinAggregation<TDocument>
     | DateHistogramAggregation<TDocument>
+    | HistogramAggregation<TDocument>
     | MissingValueAggregation<TDocument>
     | PercentileAggregation<TDocument>
     | RangeAggregation<TDocument>

--- a/src/lib/transformers/types.ts
+++ b/src/lib/transformers/types.ts
@@ -8,6 +8,7 @@ import {
     CardinalityAggregation,
     CompositeAggregation,
     DateHistogramAggregation,
+    HistogramAggregation,
     MaxAggregation,
     MinAggregation,
     PercentileAggregation,
@@ -24,7 +25,7 @@ export type TransformAggregation<
     TName extends string | number | symbol,
     TAggregation extends Aggregations<TDocument>,
     TAggregationsBody extends AggregationsBody<TDocument, AggregationsContainer<TDocument>>
-> = TAggregation extends TermsAggregation<TDocument> | DateHistogramAggregation<TDocument>
+> = TAggregation extends TermsAggregation<TDocument> | DateHistogramAggregation<TDocument> | HistogramAggregation<TDocument>
     ? Buckets<string, Bucket & TransformedAggregations<TDocument, TAggregationsBody>>
     : TAggregation extends TopHitsAggregation<TDocument>
       ? Hits<TDocument>
@@ -44,8 +45,8 @@ export type TransformAggregation<
               : TAggregation extends PercentileAggregation<TDocument>
                 ? estypes.TDigestPercentilesAggregate
                 : TAggregation extends RangeAggregation<TDocument>
-                    ? Buckets<string, RangeBucket & TransformedAggregations<TDocument, TAggregationsBody>>
-                    : `Unhandled aggregation type for name: ${TName & string}`
+                  ? Buckets<string, RangeBucket & TransformedAggregations<TDocument, TAggregationsBody>>
+                  : `Unhandled aggregation type for name: ${TName & string}`
 
 export type TransformedAggregation<
     TDocument extends Document,


### PR DESCRIPTION
According to [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-aggregations-bucket-histogram-aggregation.html) histogram aggregation can be applied on numeric values or numeric range values.