### PR TITLE
fix: syntax when installing the package with npm

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ You can install package using yarn or npm
 ```bash
 $ yarn add @codemask-labs/nestjs-elasticsearch
 // or
-$ npm -i @codemask-labs/nestjs-elasticsearch
+$ npm i @codemask-labs/nestjs-elasticsearch
 ```
 
 ## Getting started


### PR DESCRIPTION
Wrong syntax npm
replace 
``` npm -i @codemask-labs/nestjs-elasticsearch ```
to 
```npm i @codemask-labs/nestjs-elasticsearch```