### PR TITLE
feat: enable async module registration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,9 +64,15 @@ import { ElasticsearchModule } from '@codemask-labs/nestjs-elasticsearch'
 @Module({
     imports: [
         ElasticsearchModule.registerAsync({
-            useFactory: () => ({
-                node: 'http://localhost:9200',
-            })
+            imports: [ConfigModule],
+            useFactory: (configService: ConfigService) => ({
+                node: configService.get('ELASTICSEARCH_NODE'),
+                auth: {
+                    username: configService.get('ELASTICSEARCH_USERNAME'),
+                    password: configService.get('ELASTICSEARCH_PASSWORD'),
+                },
+            }),
+            inject: [ConfigService],
         })
     ]
 })

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,24 @@ import { ElasticsearchModule } from '@codemask-labs/nestjs-elasticsearch'
 class AppModule {}
 ```
 
-The `register()` method supports all the configuration properties available in `ClientOptions` from the [@elastic/elasticsearch](https://www.npmjs.com/package/@elastic/elasticsearch) package.
+or
+
+```typescript
+import { ElasticsearchModule } from '@codemask-labs/nestjs-elasticsearch'
+
+@Module({
+    imports: [
+        ElasticsearchModule.registerAsync({
+            useFactory: () => ({
+                node: 'http://localhost:9200',
+            })
+        })
+    ]
+})
+class AppModule {}
+```
+
+The `register()` and `registerAsync()` methods support all the configuration properties available in `ClientOptions` from the [@elastic/elasticsearch](https://www.npmjs.com/package/@elastic/elasticsearch) package.
 
 ### Registering the index
 

--- a/src/module/elasticsearch.module.ts
+++ b/src/module/elasticsearch.module.ts
@@ -5,6 +5,7 @@ import { ClassConstructor } from 'lib/common'
 import { Index } from './injectables'
 import { ElasticsearchService } from './elasticsearch.service'
 import { getIndexInjectionToken } from './utils'
+import { AsyncModuleOptions } from './types'
 
 @Module({})
 export class ElasticsearchModule {
@@ -13,6 +14,16 @@ export class ElasticsearchModule {
             global: true, // todo: make it optional
             module: ElasticsearchModule,
             imports: [BaseElasticsearchModule.register(options)],
+            providers: [ElasticsearchService],
+            exports: [ElasticsearchService],
+        }
+    }
+
+    static registerAsync(options: AsyncModuleOptions): DynamicModule {
+        return {
+            global: options.global ?? true,
+            module: ElasticsearchModule,
+            imports: [BaseElasticsearchModule.registerAsync(options)],
             providers: [ElasticsearchService],
             exports: [ElasticsearchService],
         }

--- a/src/module/types.ts
+++ b/src/module/types.ts
@@ -1,0 +1,11 @@
+import { DynamicModule, InjectionToken, Type } from '@nestjs/common'
+import { ClientOptions } from '@elastic/elasticsearch'
+
+export type AsyncModuleOptions = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    imports?: Array<Type<any> | DynamicModule | Promise<DynamicModule>>
+    global?: boolean
+    inject?: Array<InjectionToken>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useFactory: (...args: Array<any>) => Promise<ClientOptions> | ClientOptions
+}

--- a/src/test/features/1-making-a-search.spec.ts
+++ b/src/test/features/1-making-a-search.spec.ts
@@ -14,7 +14,6 @@ describe('Making a search', () => {
                 useFactory: () => ({
                     node: TEST_ELASTICSEARCH_NODE,
                 }),
-                global: false,
             }),
         ],
     })

--- a/src/test/features/1-making-a-search.spec.ts
+++ b/src/test/features/1-making-a-search.spec.ts
@@ -10,8 +10,11 @@ import { getQueries } from 'lib/utils'
 describe('Making a search', () => {
     const { app } = setupNestApplication({
         imports: [
-            ElasticsearchModule.register({
-                node: TEST_ELASTICSEARCH_NODE,
+            ElasticsearchModule.registerAsync({
+                useFactory: () => ({
+                    node: TEST_ELASTICSEARCH_NODE,
+                }),
+                global: false,
             }),
         ],
     })


### PR DESCRIPTION
Fix for this one: https://github.com/codemask-labs/nestjs-elasticsearch/issues/202