### PR TITLE
fix: validate @RegisterIndex in ElasticsearchService.getIndex()

### DIFF
--- a/src/module/elasticsearch.service.ts
+++ b/src/module/elasticsearch.service.ts
@@ -7,6 +7,7 @@ import { SearchRequestOptions } from 'lib/requests'
 import { getSearchResponse } from 'lib/responses'
 import { getSearchRequestParams } from 'lib/elasticsearch'
 import { Index } from './injectables'
+import { validateIndexName } from './utils'
 
 @Injectable()
 export class ElasticsearchService {
@@ -22,6 +23,8 @@ export class ElasticsearchService {
     }
 
     getIndex<TDocument extends Document>(document: ClassConstructor<TDocument>) {
+        validateIndexName(document)
+
         return new Index(this, document)
     }
 

--- a/src/module/elasticsearch.service.ts
+++ b/src/module/elasticsearch.service.ts
@@ -7,7 +7,6 @@ import { SearchRequestOptions } from 'lib/requests'
 import { getSearchResponse } from 'lib/responses'
 import { getSearchRequestParams } from 'lib/elasticsearch'
 import { Index } from './injectables'
-import { isIndexNameValid } from './utils'
 
 @Injectable()
 export class ElasticsearchService {
@@ -23,10 +22,6 @@ export class ElasticsearchService {
     }
 
     getIndex<TDocument extends Document>(document: ClassConstructor<TDocument>) {
-        if (!isIndexNameValid(document)) {
-            throw new Error(`[${document.name}] Failed to inject index. Make sure the index is properly decorated with @RegisterIndex(name: string).`)
-        }
-
         return new Index(this, document)
     }
 

--- a/src/module/elasticsearch.service.ts
+++ b/src/module/elasticsearch.service.ts
@@ -7,7 +7,7 @@ import { SearchRequestOptions } from 'lib/requests'
 import { getSearchResponse } from 'lib/responses'
 import { getSearchRequestParams } from 'lib/elasticsearch'
 import { Index } from './injectables'
-import { validateIndexName } from './utils'
+import { isIndexNameValid } from './utils'
 
 @Injectable()
 export class ElasticsearchService {
@@ -23,7 +23,9 @@ export class ElasticsearchService {
     }
 
     getIndex<TDocument extends Document>(document: ClassConstructor<TDocument>) {
-        validateIndexName(document)
+        if (!isIndexNameValid(document)) {
+            throw new Error(`[${document.name}] Failed to inject index. Make sure the index is properly decorated with @RegisterIndex(name: string).`)
+        }
 
         return new Index(this, document)
     }

--- a/src/module/injectables/index.injectable.ts
+++ b/src/module/injectables/index.injectable.ts
@@ -3,13 +3,18 @@ import { ClassConstructor, Document } from 'lib/common'
 import { AggregationsContainer } from 'lib/aggregations'
 import { SearchRequestOptions } from 'lib/requests'
 import { ElasticsearchService } from '../elasticsearch.service'
+import { isIndexRegistered } from '../utils'
 
 @Injectable()
 export class Index<TDocument extends Document> {
     constructor(
         private readonly service: ElasticsearchService,
         private readonly document: ClassConstructor<TDocument>,
-    ) {}
+    ) {
+        if (!isIndexRegistered(document)) {
+            throw new Error(`[${document.name}] Failed to construct Index. Make sure the index document class is properly decorated with @RegisterIndex(name: string).`)
+        }
+    }
 
     search<TAggregationsBody extends AggregationsContainer<TDocument>>(options?: SearchRequestOptions<TDocument, TAggregationsBody>) {
         return this.service.search(this.document, options)

--- a/src/module/utils.ts
+++ b/src/module/utils.ts
@@ -3,7 +3,7 @@ import { is } from 'ramda'
 import { ClassConstructor } from 'lib/common'
 import { ELASTICSEARCH_INDEX_NAME_METADATA, ELASTICSEARCH_INDEX_PREFIX } from 'lib/constants'
 
-export const isIndexNameValid = <T>(document: ClassConstructor<T>) => {
+export const isIndexRegistered = <T>(document: ClassConstructor<T>) => {
     const indexName = Reflect.getMetadata(ELASTICSEARCH_INDEX_NAME_METADATA, document) as string | undefined
 
     return is(String, indexName)
@@ -14,8 +14,8 @@ export const getIndexName = <T>(nameOrDocument: string | ClassConstructor<T>) =>
         return nameOrDocument
     }
 
-    if (!isIndexNameValid(nameOrDocument)) {
-        throw new Error(`[${nameOrDocument.name}] Failed to inject index. Make sure the index is properly decorated with @RegisterIndex(name: string).`)
+    if (!isIndexRegistered(nameOrDocument)) {
+        throw new Error(`[${nameOrDocument.name}] Failed to get index name. Make sure the index is properly decorated with @RegisterIndex(name: string).`)
     }
 
     return Reflect.getMetadata(ELASTICSEARCH_INDEX_NAME_METADATA, nameOrDocument) as string

--- a/src/module/utils.ts
+++ b/src/module/utils.ts
@@ -3,20 +3,22 @@ import { is, isNil } from 'ramda'
 import { ClassConstructor } from 'lib/common'
 import { ELASTICSEARCH_INDEX_NAME_METADATA, ELASTICSEARCH_INDEX_PREFIX } from 'lib/constants'
 
+export const validateIndexName = <T>(document: ClassConstructor<T>) => {
+    const indexName = Reflect.getMetadata(ELASTICSEARCH_INDEX_NAME_METADATA, document) as string | undefined
+
+    if (isNil(indexName)) {
+        throw new Error(`[${document.name}] Failed to inject index. Make sure the index is properly decorated with @RegisterIndex(name: string).`)
+    }
+}
+
 export const getIndexName = <T>(nameOrDocument: string | ClassConstructor<T>) => {
     if (is(String, nameOrDocument)) {
         return nameOrDocument
     }
 
-    const indexName = Reflect.getMetadata(ELASTICSEARCH_INDEX_NAME_METADATA, nameOrDocument) as string | undefined
+    validateIndexName(nameOrDocument)
 
-    if (isNil(indexName)) {
-        throw new Error(
-            `[${nameOrDocument.name}] Failed to inject index. Make sure the index is properly decorated with @RegisterIndex(name: string).`,
-        )
-    }
-
-    return indexName
+    return Reflect.getMetadata(ELASTICSEARCH_INDEX_NAME_METADATA, nameOrDocument) as string
 }
 
 export const getIndexInjectionToken = <T>(nameOrDocument: string | ClassConstructor<T>) =>

--- a/src/module/utils.ts
+++ b/src/module/utils.ts
@@ -1,14 +1,12 @@
 import 'reflect-metadata'
-import { is, isNil } from 'ramda'
+import { is } from 'ramda'
 import { ClassConstructor } from 'lib/common'
 import { ELASTICSEARCH_INDEX_NAME_METADATA, ELASTICSEARCH_INDEX_PREFIX } from 'lib/constants'
 
-export const validateIndexName = <T>(document: ClassConstructor<T>) => {
+export const isIndexNameValid = <T>(document: ClassConstructor<T>) => {
     const indexName = Reflect.getMetadata(ELASTICSEARCH_INDEX_NAME_METADATA, document) as string | undefined
 
-    if (isNil(indexName)) {
-        throw new Error(`[${document.name}] Failed to inject index. Make sure the index is properly decorated with @RegisterIndex(name: string).`)
-    }
+    return is(String, indexName)
 }
 
 export const getIndexName = <T>(nameOrDocument: string | ClassConstructor<T>) => {
@@ -16,7 +14,9 @@ export const getIndexName = <T>(nameOrDocument: string | ClassConstructor<T>) =>
         return nameOrDocument
     }
 
-    validateIndexName(nameOrDocument)
+    if (!isIndexNameValid(nameOrDocument)) {
+        throw new Error(`[${nameOrDocument.name}] Failed to inject index. Make sure the index is properly decorated with @RegisterIndex(name: string).`)
+    }
 
     return Reflect.getMetadata(ELASTICSEARCH_INDEX_NAME_METADATA, nameOrDocument) as string
 }

--- a/src/test/features/5-forfeature-validation.spec.ts
+++ b/src/test/features/5-forfeature-validation.spec.ts
@@ -1,0 +1,57 @@
+import { Test } from '@nestjs/testing'
+import { TEST_ELASTICSEARCH_NODE } from 'test/constants'
+import { setupNestApplication } from 'test/toolkit'
+import { ElasticsearchModule } from 'module/elasticsearch.module'
+import { ElasticsearchService } from 'module/elasticsearch.service'
+
+/**
+ * Bug (fixed): ElasticsearchService.getIndex() failed silently when passed a class
+ * without @RegisterIndex. The error only surfaced lazily at call-time inside .search().
+ *
+ * Fix: getIndex() now calls validateIndexName(document) eagerly, throwing immediately when
+ * the document is not decorated with @RegisterIndex.
+ */
+
+// Intentionally NOT decorated with @RegisterIndex
+class UnregisteredDocument { }
+
+describe('forFeature validation', () => {
+    const { app } = setupNestApplication({
+        imports: [
+            ElasticsearchModule.register({
+                node: TEST_ELASTICSEARCH_NODE,
+            }),
+        ],
+    })
+
+    it('getIndex() throws immediately when document has no @RegisterIndex', () => {
+        const service = app.get(ElasticsearchService)
+
+        expect(() => service.getIndex(UnregisteredDocument)).toThrow(
+            `[${UnregisteredDocument.name}] Failed to inject index. Make sure the index is properly decorated with @RegisterIndex(name: string).`,
+        )
+    })
+})
+
+describe('forFeature validation - startup failure', () => {
+    it('app fails to initialise when a provider uses getIndex() with an unregistered document', async () => {
+        const testingModule = Test.createTestingModule({
+            imports: [
+                ElasticsearchModule.register({
+                    node: TEST_ELASTICSEARCH_NODE,
+                }),
+            ],
+            providers: [
+                {
+                    provide: 'UNREGISTERED_INDEX',
+                    inject: [ElasticsearchService],
+                    useFactory: (service: ElasticsearchService) => service.getIndex(UnregisteredDocument),
+                },
+            ],
+        })
+
+        await expect(testingModule.compile()).rejects.toThrow(
+            `[${UnregisteredDocument.name}] Failed to inject index. Make sure the index is properly decorated with @RegisterIndex(name: string).`,
+        )
+    })
+})

--- a/src/test/features/5-forfeature-validation.spec.ts
+++ b/src/test/features/5-forfeature-validation.spec.ts
@@ -27,7 +27,7 @@ describe('forFeature validation', () => {
         const service = app.get(ElasticsearchService)
 
         expect(() => service.getIndex(UnregisteredDocument)).toThrow(
-            `[${UnregisteredDocument.name}] Failed to inject index. Make sure the index is properly decorated with @RegisterIndex(name: string).`,
+            `[${UnregisteredDocument.name}] Failed to construct Index. Make sure the index document class is properly decorated with @RegisterIndex(name: string).`,
         )
     })
 })
@@ -50,7 +50,7 @@ describe('forFeature validation - startup failure', () => {
         })
 
         await expect(testingModule.compile()).rejects.toThrow(
-            `[${UnregisteredDocument.name}] Failed to inject index. Make sure the index is properly decorated with @RegisterIndex(name: string).`,
+            `[${UnregisteredDocument.name}] Failed to construct Index. Make sure the index document class is properly decorated with @RegisterIndex(name: string).`,
         )
     })
 })

--- a/src/test/features/5-forfeature-validation.spec.ts
+++ b/src/test/features/5-forfeature-validation.spec.ts
@@ -8,8 +8,7 @@ import { ElasticsearchService } from 'module/elasticsearch.service'
  * Bug (fixed): ElasticsearchService.getIndex() failed silently when passed a class
  * without @RegisterIndex. The error only surfaced lazily at call-time inside .search().
  *
- * Fix: getIndex() now calls validateIndexName(document) eagerly, throwing immediately when
- * the document is not decorated with @RegisterIndex.
+ * Fix: getIndex() is now throwing immediately when the document is not decorated with @RegisterIndex.
  */
 
 // Intentionally NOT decorated with @RegisterIndex


### PR DESCRIPTION
ElasticsearchService.getIndex() accepted any class constructor without checking whether it was decorated with @RegisterIndex. The error only surfaced lazily when .search() was eventually called, making misconfiguration hard to diagnose.

Changes:

- Added validateIndexName(document) utility - a guard that throws a descriptive error if a class is not decorated with @RegisterIndex
- getIndex() now calls validateIndexName(document) eagerly before constructing the Index instance, so the error is raised at the earliest possible point.
- Added test cases covering both direct getIndex() usage and the provider/module startup failure scenario.