### PR TITLE
docs: add JSDoc to all public API functions and classes

### DIFF
--- a/src/lib/aggregations/get-avg.ts
+++ b/src/lib/aggregations/get-avg.ts
@@ -8,6 +8,13 @@ export type AvgAggregation<TDocument extends Document> = {
     avg: AvgAggregationBody<TDocument>
 }
 
+/**
+ * Builds an Elasticsearch `avg` aggregation that computes the arithmetic mean
+ * of numeric values extracted from the specified field across all matching documents.
+ *
+ * @param field - The numeric document field to average.
+ * @returns An `AvgAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getAvgAggregation = <TDocument extends Document>(field: NumericField<TDocument>): AvgAggregation<TDocument> => ({
     avg: { field },
 })

--- a/src/lib/aggregations/get-bucket-script.ts
+++ b/src/lib/aggregations/get-bucket-script.ts
@@ -7,6 +7,15 @@ export type BucketScriptAggregationBody = {
     script: string
 }
 
+/**
+ * Builds an Elasticsearch `bucket_script` aggregation that executes a Painless script
+ * on per-bucket metric values to compute a new derived metric. The script can reference
+ * other sibling aggregations via `bucketsPath`.
+ *
+ * @param script - A Painless script string that computes the derived value (e.g. `'params.total / params.count'`).
+ * @param bucketsPath - A map of script variable names to sibling aggregation paths (e.g. `{ total: 'sum_agg', count: 'count_agg' }`).
+ * @returns A `BucketScriptAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getBucketScriptAggregation = (script: string, bucketsPath: Record<string, string>): BucketScriptAggregation => ({
     bucket_script: {
         buckets_path: bucketsPath,

--- a/src/lib/aggregations/get-bucket-selector.ts
+++ b/src/lib/aggregations/get-bucket-selector.ts
@@ -7,6 +7,15 @@ export type BucketSelectorAggregationBody = {
     script: string
 }
 
+/**
+ * Builds an Elasticsearch `bucket_selector` aggregation that uses a Painless script
+ * to determine whether a bucket should be retained in the response. Buckets where the
+ * script evaluates to `false` are excluded from results.
+ *
+ * @param script - A Painless script string that returns a boolean (e.g. `'params.total > 100'`).
+ * @param bucketsPath - A map of script variable names to sibling aggregation paths (e.g. `{ total: 'sum_agg' }`).
+ * @returns A `BucketSelectorAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getBucketSelectorAggregation = (script: string, bucketsPath: Record<string, string>): BucketSelectorAggregation => ({
     bucket_selector: {
         buckets_path: bucketsPath,

--- a/src/lib/aggregations/get-bucket-sort.ts
+++ b/src/lib/aggregations/get-bucket-sort.ts
@@ -9,9 +9,7 @@ export type BucketSort = {
 }
 
 /**
- * @description all field are optional, because
- * you can use bucket sort for both sorting and truncating result buckets,
- * but you also can use it for only sorting or only truncating
+ * All fields are optional: use `bucket_sort` for sorting, truncating result buckets, or both.
  */
 export type BucketSortAggregationBody = {
     sort?: Array<BucketSort>
@@ -19,6 +17,14 @@ export type BucketSortAggregationBody = {
     size?: number
 }
 
+/**
+ * Builds an Elasticsearch `bucket_sort` aggregation that sorts and/or paginates the buckets
+ * of a parent aggregation. All parameters are optional: you can use it purely for sorting,
+ * purely for truncating (via `size`/`from`), or both.
+ *
+ * @param parameters - Optional sort and pagination settings: `sort` (array of bucket sort criteria), `from` (bucket offset), and `size` (max buckets to return).
+ * @returns A `BucketSortAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getBucketSortAggregation = (parameters: BucketSortAggregationBody = {}): BucketSortAggregation => ({
     bucket_sort: parameters,
 })

--- a/src/lib/aggregations/get-cardinality.ts
+++ b/src/lib/aggregations/get-cardinality.ts
@@ -23,6 +23,14 @@ export type CardinalityAggregation<TDocument extends Document> = {
     cardinality: CardinalityAggregationBody<TDocument>
 }
 
+/**
+ * Builds an Elasticsearch `cardinality` aggregation that counts an approximate number of distinct values
+ * in the specified field or from a Painless script.
+ *
+ * @param fieldOrScript - A document field name, or a `CardinalityScript` object with a Painless `script` string.
+ * @param options - Optional settings such as `precision_threshold` (max 40000, default 3000).
+ * @returns A `CardinalityAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getCardinalityAggregation = <TDocument extends Document>(
     fieldOrScript: Field<TDocument> | CardinalityScript,
     options?: CardinalityAggregationOptions,

--- a/src/lib/aggregations/get-composite.ts
+++ b/src/lib/aggregations/get-composite.ts
@@ -29,6 +29,15 @@ export type CompositeAggregation<TDocument extends Document> = {
     composite: CompositeAggregationBody<TDocument>
 }
 
+/**
+ * Builds an Elasticsearch `composite` aggregation that paginates through all buckets
+ * from multiple aggregation sources (terms, histogram, date_histogram). Use `after`
+ * in `options` with the previous response's `after_key` to fetch the next page.
+ *
+ * @param sources - An array of composite source objects, each mapping a name to a `terms`, `histogram`, or `date_histogram` aggregation.
+ * @param options - Optional settings including `size` (buckets per page) and `after` (pagination cursor).
+ * @returns A `CompositeAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getCompositeAggregation = <TDocument extends Document>(
     sources: Array<CompositeAggregationSource<TDocument>>,
     options?: CompositeAggregationOptions<TDocument>,

--- a/src/lib/aggregations/get-date-histogram.ts
+++ b/src/lib/aggregations/get-date-histogram.ts
@@ -18,6 +18,16 @@ export type DateHistogramAggregation<TDocument extends Document> = {
     date_histogram: DateHistogramAggregationBody<TDocument>
 }
 
+/**
+ * Builds an Elasticsearch `date_histogram` aggregation that groups documents into time-based
+ * buckets using a calendar or fixed interval. Can also be used as a source inside
+ * `getCompositeAggregation`.
+ *
+ * @param field - The date document field to bucket by.
+ * @param interval - A calendar interval (e.g. `CalendarIntervalName.Day`) or fixed interval quantity string.
+ * @param options - Optional settings such as `min_doc_count` to exclude empty buckets.
+ * @returns A `DateHistogramAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getDateHistogramAggregation = <TDocument extends Document>(
     field: Key<TDocument>,
     interval: ExtractEnumValues<CalendarIntervalName | CalendarIntervalQuantity>,

--- a/src/lib/aggregations/get-filter.ts
+++ b/src/lib/aggregations/get-filter.ts
@@ -7,6 +7,14 @@ export type FilterAggregation<TDocument extends Document> = {
     filter: QueryType<TDocument>
 }
 
+/**
+ * Builds an Elasticsearch `filter` aggregation that restricts the documents entering
+ * a sub-aggregation to those matching the given query. Useful for scoping nested
+ * aggregations to a filtered subset without affecting the parent result set.
+ *
+ * @param filter - A `term`, `range`, or `bool` query to use as the filter.
+ * @returns A `FilterAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getFilterAggregation = <TDocument extends Document>(filter: QueryType<TDocument>): FilterAggregation<TDocument> => ({
     filter,
 })

--- a/src/lib/aggregations/get-geo-centroid.ts
+++ b/src/lib/aggregations/get-geo-centroid.ts
@@ -8,6 +8,14 @@ export type GeoCentroidAggregation<TDocument extends Document> = {
     geo_centroid: GeoCentroidAggregationBody<TDocument>
 }
 
+/**
+ * Builds an Elasticsearch `geo_centroid` aggregation that computes the geographic
+ * centroid (weighted average of lat/lon coordinates) from a geo_point field
+ * across all matching documents.
+ *
+ * @param field - The `geo_point` document field to compute the centroid from.
+ * @returns A `GeoCentroidAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getGeoCentroidAggregation = <TDocument extends Document>(field: Field<TDocument>): GeoCentroidAggregation<TDocument> => ({
     geo_centroid: {
         field,

--- a/src/lib/aggregations/get-histogram.ts
+++ b/src/lib/aggregations/get-histogram.ts
@@ -16,6 +16,15 @@ export type HistogramAggregation<TDocument extends Document> = {
     histogram: HistogramAggregationBody<TDocument>
 }
 
+/**
+ * Builds an Elasticsearch `histogram` aggregation that groups numeric values into fixed-width
+ * buckets of the given interval. Can also be used as a source inside `getCompositeAggregation`.
+ *
+ * @param field - The numeric document field to bucket by.
+ * @param interval - The fixed bucket width (e.g. `100` groups values into 0–99, 100–199, etc.).
+ * @param options - Optional settings such as `min_doc_count` to exclude empty buckets.
+ * @returns A `HistogramAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getHistogramAggregation = <TDocument extends Document>(
     field: NumericField<TDocument>,
     interval: number,

--- a/src/lib/aggregations/get-max.ts
+++ b/src/lib/aggregations/get-max.ts
@@ -13,6 +13,13 @@ export type MaxAggregation<TDocument extends Document> = {
     max: MaxAggregationField<TDocument> | MaxAggregationScript
 }
 
+/**
+ * Builds an Elasticsearch `max` aggregation that returns the maximum numeric value
+ * from the specified field or a Painless script across all matching documents.
+ *
+ * @param fieldOrScript - A numeric document field name, or a `MaxAggregationScript` object with a Painless `script` string.
+ * @returns A `MaxAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getMaxAggregation = <TDocument extends Document>(
     fieldOrScript: NumericField<TDocument> | MaxAggregationScript,
 ): MaxAggregation<TDocument> => {

--- a/src/lib/aggregations/get-min.ts
+++ b/src/lib/aggregations/get-min.ts
@@ -13,6 +13,13 @@ export type MinAggregation<TDocument extends Document> = {
     min: MinAggregationField<TDocument> | MinAggregationScript
 }
 
+/**
+ * Builds an Elasticsearch `min` aggregation that returns the minimum numeric value
+ * from the specified field or a Painless script across all matching documents.
+ *
+ * @param fieldOrScript - A numeric document field name, or a `MinAggregationScript` object with a Painless `script` string.
+ * @returns A `MinAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getMinAggregation = <TDocument extends Document>(
     fieldOrScript: NumericField<TDocument> | MinAggregationScript,
 ): MinAggregation<TDocument> => {

--- a/src/lib/aggregations/get-missing-value.ts
+++ b/src/lib/aggregations/get-missing-value.ts
@@ -8,6 +8,14 @@ export type MissingValueAggregation<TDocument extends Document> = {
     missing: MissingValueAggregationBody<TDocument>
 }
 
+/**
+ * Builds an Elasticsearch `missing` aggregation that creates a single bucket containing
+ * all documents where the specified field has no value (is null or missing entirely).
+ * Useful for auditing data quality or handling incomplete records.
+ *
+ * @param field - The document field to check for missing values.
+ * @returns A `MissingValueAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getMissingValueAggregation = <TDocument extends Document>(field: Field<TDocument>): MissingValueAggregation<TDocument> => ({
     missing: { field },
 })

--- a/src/lib/aggregations/get-nested.ts
+++ b/src/lib/aggregations/get-nested.ts
@@ -8,6 +8,13 @@ export type NestedAggregation<TDocument extends Document> = {
     nested: NestedAggregationBody<TDocument>
 }
 
+/**
+ * Builds an Elasticsearch `nested` aggregation that allows aggregating on fields inside
+ * nested objects. Must wrap any aggregation that targets a field within a nested object type.
+ *
+ * @param path - The path to the nested object field on the document (must be a field typed as an array of objects).
+ * @returns A `NestedAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getNestedAggregation = <TDocument extends Document>(path: ArrayOfObjectsField<TDocument>): NestedAggregation<TDocument> => ({
     nested: {
         path,

--- a/src/lib/aggregations/get-percentile.ts
+++ b/src/lib/aggregations/get-percentile.ts
@@ -9,6 +9,14 @@ export type PercentileAggregation<TDocument extends Document> = {
     percentiles: PercentileAggregationBody<TDocument>
 }
 
+/**
+ * Builds an Elasticsearch `percentiles` aggregation that computes one or more percentile
+ * values of a numeric field across all matching documents.
+ *
+ * @param field - The numeric document field to compute percentiles for.
+ * @param percents - An array of percentile values to compute (e.g. `[25, 50, 75, 95, 99]`).
+ * @returns A `PercentileAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getPercentileAggregation = <TDocument extends Document>(
     field: NumericField<TDocument>,
     percents: Array<number>,

--- a/src/lib/aggregations/get-range.ts
+++ b/src/lib/aggregations/get-range.ts
@@ -9,6 +9,15 @@ export type RangeAggregation<TDocument extends Document> = {
     range: RangeAggregationBody<TDocument>
 }
 
+/**
+ * Builds an Elasticsearch `range` aggregation that groups numeric values into
+ * explicitly defined bucket ranges. Unlike `histogram`, ranges do not need to be
+ * equal in size and can be arbitrary.
+ *
+ * @param field - The numeric document field to bucket by.
+ * @param ranges - An array of `Range` objects defining the bucket boundaries (e.g. `{ from: 0, to: 100 }`).
+ * @returns A `RangeAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getRangeAggregation = <TDocument extends Document>(
     field: NumericField<TDocument>,
     ranges: Array<Range>,

--- a/src/lib/aggregations/get-stats-bucket.ts
+++ b/src/lib/aggregations/get-stats-bucket.ts
@@ -6,6 +6,13 @@ export type StatsBucketAggregationBody = {
     buckets_path: string
 }
 
+/**
+ * Builds an Elasticsearch `stats_bucket` pipeline aggregation that computes statistics
+ * (min, max, sum, count, avg) across all bucket values of a sibling aggregation.
+ *
+ * @param path - The `buckets_path` pointing to the sibling aggregation metric (e.g. `'sales_per_month>total_sales'`).
+ * @returns A `StatsBucketAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getStatsBucketAggregation = (path: string): StatsBucketAggregation => ({
     stats_bucket: {
         buckets_path: path,

--- a/src/lib/aggregations/get-sum.ts
+++ b/src/lib/aggregations/get-sum.ts
@@ -13,6 +13,13 @@ export type SumAggregation<TDocument extends Document> = {
     sum: SumAggregationField<TDocument> | SumAggregationScript
 }
 
+/**
+ * Builds an Elasticsearch `sum` aggregation that computes the total sum of numeric values
+ * from the specified field or a Painless script across all matching documents.
+ *
+ * @param fieldOrScript - A numeric document field name, or a `SumAggregationScript` object with a Painless `script` string.
+ * @returns A `SumAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getSumAggregation = <TDocument extends Document>(
     fieldOrScript: NumericField<TDocument> | SumAggregationScript,
 ): SumAggregation<TDocument> => {

--- a/src/lib/aggregations/get-top-hits.ts
+++ b/src/lib/aggregations/get-top-hits.ts
@@ -29,6 +29,15 @@ export type TopHitsAggregation<TDocument extends Document> = {
     top_hits: TopHitsAggregationBody<TDocument>
 }
 
+/**
+ * Builds an Elasticsearch `top_hits` aggregation that returns the top matching documents
+ * within each bucket of a parent aggregation. Useful for fetching representative documents
+ * per group (e.g. the newest document per category).
+ *
+ * @param size - The maximum number of top hits to return per bucket. Defaults to `3`.
+ * @param options - Optional settings including `from` (offset), `sort` (sort order), and `includes` (field projection).
+ * @returns A `TopHitsAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getTopHitsAggregation = <TDocument extends Document>(
     size: number = 3,
     options?: TopHitsAggregationOptions<TDocument>,

--- a/src/lib/aggregations/get-value-count.ts
+++ b/src/lib/aggregations/get-value-count.ts
@@ -8,6 +8,14 @@ export type ValueCountAggregation<TDocument extends Document> = {
     value_count: ValueCountAggregationBody<TDocument>
 }
 
+/**
+ * Builds an Elasticsearch `value_count` aggregation that counts the number of values
+ * extracted from the specified field across all matching documents. Unlike `cardinality`,
+ * this counts all values including duplicates.
+ *
+ * @param field - The document field to count values for.
+ * @returns A `ValueCountAggregation` object ready to be included in a search request's `aggregations`.
+ */
 export const getValueCountAggregation = <TDocument extends Document>(field: Field<TDocument>): ValueCountAggregation<TDocument> => ({
     value_count: {
         field,

--- a/src/lib/decorators/inject-index.decorator.ts
+++ b/src/lib/decorators/inject-index.decorator.ts
@@ -3,4 +3,17 @@ import { Inject } from '@nestjs/common'
 import { ClassConstructor, Document } from 'lib/common'
 import { getIndexInjectionToken } from 'module/utils'
 
+/**
+ * Property decorator that injects a typed `Index<TDocument>` instance into a NestJS service.
+ * The document class must be registered with `ElasticsearchModule.forFeature` in the consuming module.
+ *
+ * @param document - The document class decorated with `@RegisterIndex` to inject.
+ * @returns A NestJS `@Inject` decorator bound to the correct injection token for the given document.
+ *
+ * @example
+ * ```ts
+ * @InjectIndex(HomeDocument)
+ * private readonly homeIndex: Index<HomeDocument>
+ * ```
+ */
 export const InjectIndex = <TDocument extends Document>(document: ClassConstructor<TDocument>) => Inject(getIndexInjectionToken(document))

--- a/src/lib/decorators/register-index.decorator.ts
+++ b/src/lib/decorators/register-index.decorator.ts
@@ -2,6 +2,22 @@ import 'reflect-metadata'
 import { is, isEmpty, isNil } from 'ramda'
 import { ELASTICSEARCH_INDEX_NAME_METADATA } from 'lib/constants'
 
+/**
+ * Class decorator that registers a document class as an Elasticsearch index.
+ * Stores the index name in Reflect metadata so the module can resolve it at runtime.
+ * Must be applied to every document class passed to `ElasticsearchModule.forFeature`.
+ *
+ * @param name - The Elasticsearch index name to associate with this document class.
+ * @returns A class decorator that attaches the index name to the decorated class.
+ *
+ * @example
+ * ```ts
+ * @RegisterIndex('homes')
+ * class HomeDocument {
+ *   title: string
+ * }
+ * ```
+ */
 export const RegisterIndex =
     (name: string) =>
     <T>(constructor: new () => T): new () => T => {

--- a/src/lib/elasticsearch/get-search-request-params.ts
+++ b/src/lib/elasticsearch/get-search-request-params.ts
@@ -2,6 +2,15 @@ import { ClassConstructor, Document } from 'lib/common'
 import { AggregationsContainer } from 'lib/aggregations'
 import { SearchRequest, SearchRequestOptions, getSearchRequest } from 'lib/requests'
 
+/**
+ * Builds the Elasticsearch client search parameters from a document class and search options.
+ * This is a thin adapter over `getSearchRequest` that extracts and returns only the fields
+ * accepted by the underlying `@elastic/elasticsearch` client's `search` method.
+ *
+ * @param document - The document class decorated with `@RegisterIndex` that identifies the target index.
+ * @param options - Optional search options including `query`, `aggregations`, `size`, `from`, `sort`, and `search_after`.
+ * @returns A `SearchRequest` object ready to be passed directly to the Elasticsearch client.
+ */
 export const getSearchRequestParams = <TDocument extends Document, TAggregationsBody extends AggregationsContainer<TDocument>>(
     document: ClassConstructor<TDocument>,
     options?: SearchRequestOptions<TDocument, TAggregationsBody>,

--- a/src/lib/parameters/get-minimum-should-match.ts
+++ b/src/lib/parameters/get-minimum-should-match.ts
@@ -2,6 +2,14 @@ export type MinimumShouldMatchParameter = {
     minimum_should_match?: number | string
 }
 
+/**
+ * Builds a `minimum_should_match` parameter for use inside a `bool` query.
+ * Controls how many of the `should` clauses a document must match to be included in results.
+ * Pass the result directly to `getBoolQuery` alongside a `getShouldQuery` clause.
+ *
+ * @param value - The minimum number (e.g. `1`) or percentage string (e.g. `'75%'`) of `should` clauses that must match.
+ * @returns A `MinimumShouldMatchParameter` object to be composed into a `getBoolQuery` call.
+ */
 export const getMinimumShouldMatchParameter = (value: number | string): MinimumShouldMatchParameter => ({
     minimum_should_match: value,
 })

--- a/src/lib/queries/get-bool.ts
+++ b/src/lib/queries/get-bool.ts
@@ -14,6 +14,14 @@ export type BoolQuery<TDocument extends Document> = {
     bool: BoolQueryBody<TDocument> | Array<BoolQueryBody<TDocument>>
 }
 
+/**
+ * Builds an Elasticsearch `bool` query wrapping one or more `must`, `should`, `must_not`,
+ * or `minimum_should_match` clauses. Combine with `getMustQuery`, `getShouldQuery`, and
+ * `getMustNotQuery` to compose compound queries.
+ *
+ * @param bool - A single bool clause or an array of bool clauses to include in the query.
+ * @returns A `BoolQuery` object ready to be passed to a search request.
+ */
 export const getBoolQuery = <TDocument extends Document>(bool: BoolQueryBody<TDocument> | Array<BoolQueryBody<TDocument>>): BoolQuery<TDocument> => ({
     bool,
 })

--- a/src/lib/queries/get-exists.ts
+++ b/src/lib/queries/get-exists.ts
@@ -8,6 +8,13 @@ export type ExistsQuery<TDocument extends Document, TKeyword extends Field<TDocu
     exists: ExistsQueryBody<TDocument, TKeyword>
 }
 
+/**
+ * Builds an Elasticsearch `exists` query that matches documents where the specified field
+ * has a non-null, non-missing value.
+ *
+ * @param field - The document field to check for existence. Must be a valid key of `TDocument`.
+ * @returns An `ExistsQuery` object ready to be passed to a search request.
+ */
 export const getExistsQuery = <TDocument extends Document, TKeyword extends Field<TDocument> = Field<TDocument>>(
     field: TKeyword,
 ): ExistsQuery<TDocument, TKeyword> => ({

--- a/src/lib/queries/get-match-phrase-prefix.ts
+++ b/src/lib/queries/get-match-phrase-prefix.ts
@@ -16,6 +16,16 @@ export type MatchPhrasePrefixQuery<TDocument extends Document, TField extends Ke
     match_phrase_prefix: MatchPhrasePrefixQueryBody<TDocument, TField>
 }
 
+/**
+ * Builds an Elasticsearch `match_phrase_prefix` query that matches documents where the given
+ * field contains the specified phrase, allowing the last term to be a prefix. Useful for
+ * implementing search-as-you-type functionality.
+ *
+ * @param field - The document field to search against.
+ * @param query - The phrase (with optional trailing prefix) to match.
+ * @param options - Optional settings such as `boost`.
+ * @returns A `MatchPhrasePrefixQuery` object ready to be passed to a search request.
+ */
 export const getMatchPhrasePrefixQuery = <TDocument extends Document, TField extends Key<TDocument> = Key<TDocument>>(
     field: TField,
     query: FieldType<TDocument, TField>,

--- a/src/lib/queries/get-match.ts
+++ b/src/lib/queries/get-match.ts
@@ -26,6 +26,16 @@ export type MatchQuery<TDocument extends Document, TKeyword extends Field<TDocum
     match: MatchQueryBody<TDocument, TKeyword>
 }
 
+/**
+ * Builds an Elasticsearch `match` query for full-text search on a given field.
+ * The query analyzes the input text and matches documents containing any of the resulting tokens.
+ * Supports fuzziness and boost via `options`.
+ *
+ * @param field - The document field to run the match query against.
+ * @param query - The text value to search for.
+ * @param options - Optional settings such as `boost`, `prefix_length`, and `fuzziness`.
+ * @returns A `MatchQuery` object ready to be passed to a search request.
+ */
 export const getMatchQuery = <TDocument extends Document, TKeyword extends Field<TDocument> = Field<TDocument>>(
     field: TKeyword,
     query: FieldType<TDocument, TKeyword>,

--- a/src/lib/queries/get-must-not.ts
+++ b/src/lib/queries/get-must-not.ts
@@ -16,6 +16,14 @@ export type MustNotQuery<TDocument extends Document> = {
     must_not: MustNotQueryBody<TDocument> | Array<MustNotQueryBody<TDocument>>
 }
 
+/**
+ * Builds the `must_not` clause for a `bool` query. Documents matching any of the provided
+ * queries are excluded from results. Matching does not affect the relevance score.
+ * Pass the result to `getBoolQuery`.
+ *
+ * @param mustNot - A single query clause or an array of query clauses that must not match.
+ * @returns A `MustNotQuery` object to be composed into a `getBoolQuery` call.
+ */
 export const getMustNotQuery = <TDocument extends Document>(
     mustNot: MustNotQueryBody<TDocument> | Array<MustNotQueryBody<TDocument>>,
 ): MustNotQuery<TDocument> => ({

--- a/src/lib/queries/get-must.ts
+++ b/src/lib/queries/get-must.ts
@@ -22,6 +22,13 @@ export type MustQuery<TDocument extends Document> = {
     must: MustQueryBody<TDocument> | Array<MustQueryBody<TDocument>>
 }
 
+/**
+ * Builds the `must` clause for a `bool` query. Documents must match all provided queries
+ * and their scores contribute to the overall relevance score. Pass the result to `getBoolQuery`.
+ *
+ * @param must - A single query clause or an array of query clauses that all must match.
+ * @returns A `MustQuery` object to be composed into a `getBoolQuery` call.
+ */
 export const getMustQuery = <TDocument extends Document>(must: MustQueryBody<TDocument> | Array<MustQueryBody<TDocument>>): MustQuery<TDocument> => ({
     must,
 })

--- a/src/lib/queries/get-range.ts
+++ b/src/lib/queries/get-range.ts
@@ -22,6 +22,15 @@ export type RangeQuery<TDocument extends Document, TKeyword extends Field<TDocum
     range: RangeQueryBody<TDocument, TKeyword>
 }
 
+/**
+ * Builds an Elasticsearch `range` query that matches documents where the given field value
+ * falls within the specified bounds. Supports numeric, date, and string field types.
+ * Use `gt`, `gte`, `lt`, `lte` in `options` to define the range boundaries.
+ *
+ * @param field - The document field to apply the range filter on.
+ * @param options - Range bounds (`gt`, `gte`, `lt`, `lte`) and optional `format` for date fields.
+ * @returns A `RangeQuery` object ready to be passed to a search request.
+ */
 export const getRangeQuery = <TDocument extends Document, TKeyword extends Field<TDocument> = Field<TDocument>>(
     field: TKeyword,
     options: RangeQueryOptions<TDocument, TKeyword>,

--- a/src/lib/queries/get-should.ts
+++ b/src/lib/queries/get-should.ts
@@ -20,6 +20,15 @@ export type ShouldQuery<TDocument extends Document> = {
     should: ShouldQueryBody<TDocument> | Array<ShouldQueryBody<TDocument>>
 }
 
+/**
+ * Builds the `should` clause for a `bool` query. Documents matching at least one of the provided
+ * queries are preferred and receive a higher relevance score. Use `minimum_should_match` via
+ * `getMinimumShouldMatchParameter` to require a minimum number of matches.
+ * Pass the result to `getBoolQuery`.
+ *
+ * @param should - A single query clause or an array of query clauses where at least one should match.
+ * @returns A `ShouldQuery` object to be composed into a `getBoolQuery` call.
+ */
 export const getShouldQuery = <TDocument extends Document>(
     should: ShouldQueryBody<TDocument> | Array<ShouldQueryBody<TDocument>>,
 ): ShouldQuery<TDocument> => ({

--- a/src/lib/queries/get-term.ts
+++ b/src/lib/queries/get-term.ts
@@ -24,6 +24,17 @@ export type TermQuery<TDocument extends Document, TKeyword extends Field<TDocume
     term: TermQueryBody<TDocument, TKeyword>
 }
 
+/**
+ * Builds an Elasticsearch `term` query that matches documents where the given field contains
+ * the exact specified value. When `value` is a concrete non-nil value, the return type is
+ * non-nullable. When `value` is `null` or `undefined`, returns `null` — making it safe to use
+ * with optional filter values. Pass results through `getQueries` to filter out nulls.
+ *
+ * @param field - The document field to filter on.
+ * @param value - The exact value to match, or `null`/`undefined` to skip the query.
+ * @param options - Optional settings such as `boost` and `case_insensitive`.
+ * @returns A `TermQuery` if value is present, or `null`/`undefined` if value is nil.
+ */
 export interface TermQueryOverloads {
     <TDocument extends Document, TField extends Field<TDocument> = Field<TDocument>>(
         field: TField,

--- a/src/lib/queries/get-terms.ts
+++ b/src/lib/queries/get-terms.ts
@@ -17,6 +17,17 @@ export type TermsQuery<TDocument extends Document, TKeyword extends Field<TDocum
     terms: TermsQueryBody<TDocument, TKeyword>
 }
 
+/**
+ * Builds an Elasticsearch `terms` query that matches documents where the given field contains
+ * any value from the provided array. When `value` is a concrete non-nil array, the return type
+ * is non-nullable. When `value` is `null` or `undefined`, returns `null` — making it safe to use
+ * with optional filter values. Pass results through `getQueries` to filter out nulls.
+ *
+ * @param field - The document field to filter on.
+ * @param value - An array of exact values to match, or `null`/`undefined` to skip the query.
+ * @param options - Optional settings such as `boost`.
+ * @returns A `TermsQuery` if value is present, or `null`/`undefined` if value is nil.
+ */
 export interface TermsQuerySignatures {
     <TDocument extends Document, TField extends Field<TDocument> = Field<TDocument>>(
         field: TField,

--- a/src/lib/requests/get-search-request.ts
+++ b/src/lib/requests/get-search-request.ts
@@ -22,6 +22,15 @@ export type SearchRequest<TDocument extends Document, TAggregationsBody extends 
     search_after?: Array<any> // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
+/**
+ * Builds a fully typed Elasticsearch search request body by combining the index name
+ * (resolved from the document class via `@RegisterIndex` metadata) with the provided
+ * search options.
+ *
+ * @param document - The document class decorated with `@RegisterIndex` that identifies the target index.
+ * @param options - Optional search options including `query`, `aggregations`, `size`, `from`, `sort`, and `search_after`.
+ * @returns A `SearchRequest` object containing the resolved `index` name and all provided search parameters.
+ */
 export const getSearchRequest = <TDocument extends Document, TAggregationsBody extends AggregationsContainer<TDocument>>(
     document: ClassConstructor<TDocument>,
     options?: SearchRequestOptions<TDocument, TAggregationsBody>,

--- a/src/lib/responses/search.ts
+++ b/src/lib/responses/search.ts
@@ -9,6 +9,16 @@ export type SearchResponse<TDocument extends Document, TAggregationsBody extends
     aggregations: TransformedAggregations<TDocument, TAggregationsBody>
 }
 
+/**
+ * Transforms a raw Elasticsearch search response into the typed `SearchResponse` shape.
+ * Extracts the total hit count, instantiates each hit's `_source` as the document class,
+ * and casts aggregations to the typed `TransformedAggregations` shape inferred from
+ * the search request's `aggregations` parameter.
+ *
+ * @param document - The document class constructor used to instantiate each returned hit.
+ * @param response - The raw search response from the Elasticsearch client.
+ * @returns A `SearchResponse<TDocument, TAggregationsBody>` containing `total`, `documents`, and `aggregations`.
+ */
 export const getSearchResponse = <TDocument extends Document, TAggregationsBody extends AggregationsContainer<TDocument>>(
     document: ClassConstructor<TDocument>,
     { hits, aggregations }: BaseSearchResponse<TDocument, TAggregationsBody>,

--- a/src/lib/transformers/get-aggregations.ts
+++ b/src/lib/transformers/get-aggregations.ts
@@ -3,6 +3,14 @@ import { AggregationsContainer } from 'lib/aggregations'
 import { TransformedAggregations } from './types'
 import { AggregateName, AggregationsAggregate } from '@elastic/elasticsearch/lib/api/types'
 
+/**
+ * Casts the raw Elasticsearch aggregations response into the typed `TransformedAggregations` shape
+ * inferred from the `TAggregationsBody` passed to the search request. This provides full type safety
+ * on aggregation result access without runtime transformation overhead.
+ *
+ * @param aggregations - The raw aggregations map from the Elasticsearch response. Defaults to an empty object.
+ * @returns The same aggregations object cast to `TransformedAggregations<TDocument, TAggregationsBody>`.
+ */
 export const getTransformedAggregations = <TDocument extends Document, TAggregationsBody extends AggregationsContainer<TDocument>>(
     aggregations: Record<AggregateName, AggregationsAggregate> = {},
 ): TransformedAggregations<TDocument, TAggregationsBody> => aggregations as TransformedAggregations<TDocument, TAggregationsBody>

--- a/src/lib/transformers/get-documents.ts
+++ b/src/lib/transformers/get-documents.ts
@@ -2,6 +2,16 @@ import { SearchHitsMetadata } from '@elastic/elasticsearch/lib/api/types'
 import { ClassConstructor, Document } from 'lib/common'
 import { TDocumentWrapper } from './types'
 
+/**
+ * Transforms raw Elasticsearch hits into typed `TDocumentWrapper` objects.
+ * Each hit's `_source` is instantiated as the document class (preserving prototype methods),
+ * and the raw `sort` values are preserved for use with `search_after` pagination.
+ * Hits without a `_source` are silently excluded.
+ *
+ * @param document - The document class constructor used to instantiate each hit's `_source`.
+ * @param hits - The `hits` metadata object from the raw Elasticsearch search response.
+ * @returns An array of `TDocumentWrapper<TDocument>` objects, each containing `source` and optional `sort`.
+ */
 export const getTransformedDocuments = <TDocument extends Document>(
     document: ClassConstructor<TDocument>,
     { hits }: SearchHitsMetadata<TDocument>,

--- a/src/lib/transformers/get-total.ts
+++ b/src/lib/transformers/get-total.ts
@@ -3,5 +3,13 @@ import { SearchHitsMetadata } from '@elastic/elasticsearch/lib/api/types'
 import { Document } from 'lib/common'
 import { isTotalHits } from 'lib/utils'
 
+/**
+ * Extracts the total hit count from Elasticsearch `hits` metadata as a plain number.
+ * Handles both the legacy `number` format and the modern `TotalHits` object format
+ * (introduced in ES 7+). Returns `0` if the total is absent or unrecognised.
+ *
+ * @param hits - The `hits` metadata object from the raw Elasticsearch search response.
+ * @returns The total number of matching documents as a plain `number`.
+ */
 export const getTransformedTotal = <TDocument extends Document>({ total }: SearchHitsMetadata<TDocument>): number =>
     is(Number, total) ? total : isTotalHits(total) ? total.value : 0

--- a/src/lib/utils/get-composite-sources.ts
+++ b/src/lib/utils/get-composite-sources.ts
@@ -1,4 +1,12 @@
 import { CompositeAggregationSource } from 'lib/aggregations'
 import { Document } from 'lib/common'
 
+/**
+ * Returns a shallow copy of the composite aggregation sources array.
+ * Use this to safely construct the `sources` parameter for `getCompositeAggregation`
+ * from an existing array without mutating the original.
+ *
+ * @param sources - An array of composite aggregation source objects.
+ * @returns A new array containing the same composite aggregation source objects.
+ */
 export const getCompositeSources = <TDocument extends Document>(sources: Array<CompositeAggregationSource<TDocument>>) => [...sources]

--- a/src/lib/utils/get-queries.ts
+++ b/src/lib/utils/get-queries.ts
@@ -11,5 +11,14 @@ export type QueriesBody<TDocument extends Document> =
     | MatchPhrasePrefixQuery<TDocument>
     | MustQuery<TDocument>
 
+/**
+ * Filters out `null` and `undefined` entries from an array of query clauses.
+ * Designed to work with nullable query builders like `getTermQuery` and `getTermsQuery`,
+ * which return `null` when passed a nil value. The resulting array is safe to pass
+ * directly to `getMustQuery`, `getShouldQuery`, or `getMustNotQuery`.
+ *
+ * @param filters - An array of query clauses that may include `null` or `undefined` entries.
+ * @returns A new array with all `null` and `undefined` entries removed.
+ */
 export const getQueries = <TDocument extends Document>(filters: Array<Nullable<QueriesBody<TDocument>>>): Array<QueriesBody<TDocument>> =>
     reject(isNil, filters)

--- a/src/lib/utils/get-should-not.ts
+++ b/src/lib/utils/get-should-not.ts
@@ -3,6 +3,15 @@ import { getBoolQuery, getMustNotQuery, getShouldQuery, MustNotQueryBody, Should
 
 export type ShouldNotQuery<TDocument extends Document> = ShouldQuery<TDocument>
 
+/**
+ * Builds a `should` clause containing a `bool` query with a `must_not` condition.
+ * This is a convenience wrapper that produces the Elasticsearch equivalent of
+ * "should not match" — documents matching the inner clause are deprioritised rather
+ * than excluded. To hard-exclude documents, use `getMustNotQuery` directly inside `getBoolQuery`.
+ *
+ * @param body - A single query clause or array of query clauses that should not match.
+ * @returns A `ShouldNotQuery` (typed as `ShouldQuery`) wrapping a `bool.must_not` clause.
+ */
 export const getShouldNotQuery = <TDocument extends Document>(
     body: MustNotQueryBody<TDocument> | Array<MustNotQueryBody<TDocument>>,
 ): ShouldNotQuery<TDocument> => getShouldQuery(getBoolQuery(getMustNotQuery(body)))

--- a/src/lib/utils/is-keyed-percentiles.ts
+++ b/src/lib/utils/is-keyed-percentiles.ts
@@ -1,3 +1,11 @@
 import { AggregationsKeyedPercentiles, AggregationsPercentiles } from '@elastic/elasticsearch/lib/api/types'
 
+/**
+ * Type guard that returns `true` if the given Elasticsearch percentiles result is in keyed format
+ * (i.e. an object with numeric string keys) rather than the array-of-objects format.
+ * Use this before accessing percentile values to determine the correct access pattern.
+ *
+ * @param value - The raw percentiles aggregation result from an Elasticsearch response.
+ * @returns `true` if `value` is `AggregationsKeyedPercentiles`, `false` if it is an array.
+ */
 export const isKeyedPercentiles = (value: AggregationsPercentiles): value is AggregationsKeyedPercentiles => !Array.isArray(value)

--- a/src/lib/utils/is-total-hits.ts
+++ b/src/lib/utils/is-total-hits.ts
@@ -1,6 +1,14 @@
 import { is } from 'ramda'
 import { SearchTotalHits } from '@elastic/elasticsearch/lib/api/types'
 
+/**
+ * Type guard that returns `true` if the given value is a `SearchTotalHits` object
+ * (i.e. `{ value: number, relation: string }`) as returned by Elasticsearch 7+
+ * when `rest_total_hits_as_int` is not set. Returns `false` for plain number totals.
+ *
+ * @param object - The raw `total` value from an Elasticsearch `hits` metadata object.
+ * @returns `true` if `object` is a `SearchTotalHits` instance, `false` otherwise.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isTotalHits = (object: any): object is SearchTotalHits => {
     if (is(Object, object) && is(Number, object.value)) {

--- a/src/module/elasticsearch.module.ts
+++ b/src/module/elasticsearch.module.ts
@@ -9,6 +9,13 @@ import { AsyncModuleOptions } from './types'
 
 @Module({})
 export class ElasticsearchModule {
+    /**
+     * Registers the Elasticsearch module synchronously with static client options.
+     * The module is registered globally by default.
+     *
+     * @param options - Elasticsearch client options (e.g. `node`, `auth`, `tls`).
+     * @returns A dynamic NestJS module with `ElasticsearchService` exported globally.
+     */
     static register(options: ClientOptions): DynamicModule {
         return {
             global: true, // todo: make it optional
@@ -19,6 +26,13 @@ export class ElasticsearchModule {
         }
     }
 
+    /**
+     * Registers the Elasticsearch module asynchronously, e.g. with `useFactory` or `useClass`.
+     * Supports async configuration from environment variables or config services.
+     *
+     * @param options - Async module options including `useFactory`, `inject`, and optional `global` flag.
+     * @returns A dynamic NestJS module with `ElasticsearchService` exported.
+     */
     static registerAsync(options: AsyncModuleOptions): DynamicModule {
         return {
             global: options.global ?? true,
@@ -29,6 +43,14 @@ export class ElasticsearchModule {
         }
     }
 
+    /**
+     * Registers document classes as injectable `Index<TDocument>` providers in the current module.
+     * Each document class must be decorated with `@RegisterIndex`. Call this in the feature module
+     * that owns the document, then inject with `@InjectIndex(MyDocument)`.
+     *
+     * @param documents - Array of document classes decorated with `@RegisterIndex`.
+     * @returns A dynamic NestJS module exporting one `Index<TDocument>` provider per document class.
+     */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     static forFeature(documents: Array<ClassConstructor<any>>): DynamicModule {
         const providers: Array<Provider> = documents.map(document => ({

--- a/src/module/elasticsearch.service.ts
+++ b/src/module/elasticsearch.service.ts
@@ -12,6 +12,14 @@ import { Index } from './injectables'
 export class ElasticsearchService {
     constructor(private readonly baseElasticsearchService: BaseElasticsearchService) {}
 
+    /**
+     * Executes a search against the Elasticsearch index associated with the given document class.
+     * Returns a typed `SearchResponse` with total hit count, documents, and transformed aggregations.
+     *
+     * @param document - The document class decorated with `@RegisterIndex` that identifies the target index.
+     * @param options - Optional search options including `query`, `aggregations`, `size`, `from`, `sort`, and `search_after`.
+     * @returns A promise resolving to `SearchResponse<TDocument, TAggregationsBody>` with typed hits and aggregations.
+     */
     search<TDocument extends Document, TAggregationsBody extends AggregationsContainer<TDocument>>(
         document: ClassConstructor<TDocument>,
         options?: SearchRequestOptions<TDocument, TAggregationsBody>,
@@ -21,14 +29,34 @@ export class ElasticsearchService {
         return this.baseElasticsearchService.search<TDocument, TAggregationsBody>(params).then(response => getSearchResponse(document, response))
     }
 
+    /**
+     * Creates and returns a typed `Index<TDocument>` instance for the given document class.
+     * Use this when you need a programmatic handle to an index outside of NestJS DI.
+     * Prefer `@InjectIndex` for standard service injection.
+     *
+     * @param document - The document class decorated with `@RegisterIndex`.
+     * @returns A new `Index<TDocument>` instance bound to this service.
+     */
     getIndex<TDocument extends Document>(document: ClassConstructor<TDocument>) {
         return new Index(this, document)
     }
 
+    /**
+     * Returns the Elasticsearch cluster health status.
+     *
+     * @param options - Optional cluster health request parameters (e.g. `index`, `timeout`, `wait_for_status`).
+     * @returns A promise resolving to the cluster health response body.
+     */
     getClusterHealth(options?: ClusterHealthRequest): Promise<ClusterHealthHealthResponseBody> {
         return this.baseElasticsearchService.cluster.health(options)
     }
 
+    /**
+     * Returns the underlying `@nestjs/elasticsearch` service instance.
+     * Use this to access Elasticsearch APIs not yet wrapped by this library.
+     *
+     * @returns The base `ElasticsearchService` from `@nestjs/elasticsearch`.
+     */
     getBaseService(): BaseElasticsearchService {
         return this.baseElasticsearchService
     }

--- a/src/module/injectables/index.injectable.ts
+++ b/src/module/injectables/index.injectable.ts
@@ -12,10 +12,19 @@ export class Index<TDocument extends Document> {
         private readonly document: ClassConstructor<TDocument>,
     ) {
         if (!isIndexRegistered(document)) {
-            throw new Error(`[${document.name}] Failed to construct Index. Make sure the index document class is properly decorated with @RegisterIndex(name: string).`)
+            throw new Error(
+                `[${document.name}] Failed to construct Index. Make sure the index document class is properly decorated with @RegisterIndex(name: string).`,
+            )
         }
     }
 
+    /**
+     * Executes a typed search against the Elasticsearch index for this document class.
+     * Aggregation result types are inferred from the `aggregations` shape passed in `options`.
+     *
+     * @param options - Optional search options including `query`, `aggregations`, `size`, `from`, `sort`, and `search_after`.
+     * @returns A promise resolving to `SearchResponse<TDocument, TAggregationsBody>` with typed hits and aggregations.
+     */
     search<TAggregationsBody extends AggregationsContainer<TDocument>>(options?: SearchRequestOptions<TDocument, TAggregationsBody>) {
         return this.service.search(this.document, options)
     }

--- a/src/module/utils.ts
+++ b/src/module/utils.ts
@@ -3,23 +3,46 @@ import { is } from 'ramda'
 import { ClassConstructor } from 'lib/common'
 import { ELASTICSEARCH_INDEX_NAME_METADATA, ELASTICSEARCH_INDEX_PREFIX } from 'lib/constants'
 
+/**
+ * Returns `true` if the given document class has been decorated with `@RegisterIndex`.
+ *
+ * @param document - The document class constructor to check.
+ * @returns `true` if the class has a registered Elasticsearch index name, `false` otherwise.
+ */
 export const isIndexRegistered = <T>(document: ClassConstructor<T>) => {
     const indexName = Reflect.getMetadata(ELASTICSEARCH_INDEX_NAME_METADATA, document) as string | undefined
 
     return is(String, indexName)
 }
 
+/**
+ * Resolves the Elasticsearch index name from either a string or a document class.
+ * When given a class, reads the name stored by `@RegisterIndex` from Reflect metadata.
+ * Throws a descriptive error if the class is missing the `@RegisterIndex` decorator.
+ *
+ * @param nameOrDocument - A plain index name string, or a document class decorated with `@RegisterIndex`.
+ * @returns The resolved Elasticsearch index name string.
+ */
 export const getIndexName = <T>(nameOrDocument: string | ClassConstructor<T>) => {
     if (is(String, nameOrDocument)) {
         return nameOrDocument
     }
 
     if (!isIndexRegistered(nameOrDocument)) {
-        throw new Error(`[${nameOrDocument.name}] Failed to get index name. Make sure the index is properly decorated with @RegisterIndex(name: string).`)
+        throw new Error(
+            `[${nameOrDocument.name}] Failed to get index name. Make sure the index is properly decorated with @RegisterIndex(name: string).`,
+        )
     }
 
     return Reflect.getMetadata(ELASTICSEARCH_INDEX_NAME_METADATA, nameOrDocument) as string
 }
 
+/**
+ * Returns the NestJS DI injection token used to register and resolve an `Index<TDocument>` provider.
+ * The token is derived from the index name and is used internally by `forFeature` and `@InjectIndex`.
+ *
+ * @param nameOrDocument - A plain index name string, or a document class decorated with `@RegisterIndex`.
+ * @returns The injection token string for the given index.
+ */
 export const getIndexInjectionToken = <T>(nameOrDocument: string | ClassConstructor<T>) =>
     `${ELASTICSEARCH_INDEX_PREFIX}:${getIndexName(nameOrDocument)}`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "module": "Node16",
         "lib": ["esnext"],
         "types": ["expect-more-jest"],
-        "removeComments": true,
+        "removeComments": false,
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Added JSDoc with `@param` and `@returns` tags to every exported function and class.
